### PR TITLE
Add new rule for sharing Facebook pages and other groups

### DIFF
--- a/rules.yml
+++ b/rules.yml
@@ -40,6 +40,9 @@
 - title: 'Don''t delete your topics'
   description: 'Don''t delete your topics once solutions were provided. Respect time of others willing to help you. Leaving topics available in the group might also help someone as you in the future. Topics are also visible in Facebook group search and therefore available for people looking for existing solutions.'
 
+- title: 'Sharing Facebook pages should be done only in dedicated topic for Facebook pages'
+  description: 'We don''t allow sharing offtopic Facebook pages for increasing likes because they mostly disorient other discussions in the group. We have a <a href="https://fb.com/groups/2204685680/permalink">special dedicated topic</a> available for that.'
+
 - title: 'Follow Facebook community standards'
   description: 'Our group is located on Facebook network which means you must follow and respect <a href="https://www.facebook.com/communitystandards">Facebook community standards</a> as well. That also means autoliker scripts are not allowed.'
 

--- a/rules.yml
+++ b/rules.yml
@@ -3,6 +3,11 @@
 
 - title: 'Your topic has to be web development-centric'
   description: 'You are, or will be, a member of a PHP group that allows the discussion of web development topics, this includes topics about PHP, embeddable, client-related or service-extending languages (including NodeJS, JavaScript, CSS), XML, XSLT, YAML and others. You should keep in mind that our group is generally a PHP group. A good mix is what we would see and what we would allow, otherwise 14 days long periods of NodeJS-discussions are not part of our goals. This rule may be improved and reduced to a lower set of languages in the future, depending on how the group acts. How to ask technical questions is described in details in this <a href="http://wwphp-fb.github.io/articles/how-to-ask-technical-questions/">article</a>.'
+  subrules:
+    - title: 'Sharing Facebook pages'
+      description: 'We don''t allow sharing offtopic Facebook pages for increasing likes because they mostly disorient other discussions in the group. We have a <a href="https://fb.com/groups/2204685680/permalink">special dedicated topic</a> available for that.'
+    - title: 'Sharing Facebook groups'
+      description: 'We don''t allow sharing offtopic Facebook groups but we allow and encourage using <a href="https://fb.com/groups/2204685680/permalink">dedicated topic</a> for that.'
 
 - title: 'Be social'
   description: 'Our group has no place for harassments, insults or any kind of copyright infringement. You should treat others as you want them to treat you.'
@@ -39,9 +44,6 @@
 
 - title: 'Don''t delete your topics'
   description: 'Don''t delete your topics once solutions were provided. Respect time of others willing to help you. Leaving topics available in the group might also help someone as you in the future. Topics are also visible in Facebook group search and therefore available for people looking for existing solutions.'
-
-- title: 'Sharing Facebook pages should be done only in dedicated topic for Facebook pages'
-  description: 'We don''t allow sharing offtopic Facebook pages for increasing likes because they mostly disorient other discussions in the group. We have a <a href="https://fb.com/groups/2204685680/permalink">special dedicated topic</a> available for that.'
 
 - title: 'Follow Facebook community standards'
   description: 'Our group is located on Facebook network which means you must follow and respect <a href="https://www.facebook.com/communitystandards">Facebook community standards</a> as well. That also means autoliker scripts are not allowed.'

--- a/rules.yml
+++ b/rules.yml
@@ -1,13 +1,15 @@
 - title: 'English, please'
   description: 'The group language was, would be in the future and is English. We will delete topics and comments that are not localized to English. If you are not able to communicate in English <a href="https://google.com/translate">Google Translate</a> may be an option. Read more at the <a href="http://wwphp-fb.github.io/rules.html#faq-1">rules FAQ</a> why we use only English here and where to find your local groups.'
 
-- title: 'Your topic has to be web development-centric'
+- title: 'Your topic must be web development-centric'
   description: 'You are, or will be, a member of a PHP group that allows the discussion of web development topics, this includes topics about PHP, embeddable, client-related or service-extending languages (including NodeJS, JavaScript, CSS), XML, XSLT, YAML and others. You should keep in mind that our group is generally a PHP group. A good mix is what we would see and what we would allow, otherwise 14 days long periods of NodeJS-discussions are not part of our goals. This rule may be improved and reduced to a lower set of languages in the future, depending on how the group acts. How to ask technical questions is described in details in this <a href="http://wwphp-fb.github.io/articles/how-to-ask-technical-questions/">article</a>.'
   subrules:
     - title: 'Sharing Facebook pages'
       description: 'We don''t allow sharing offtopic Facebook pages for increasing likes because they mostly disorient other discussions in the group. We have a <a href="https://fb.com/groups/2204685680/permalink">special dedicated topic</a> available for that.'
     - title: 'Sharing Facebook groups'
       description: 'We don''t allow sharing offtopic Facebook groups but we allow and encourage using <a href="https://fb.com/groups/2204685680/permalink">dedicated topic</a> for that.'
+    - title: 'Job opportunities'
+      description: 'Job opportunities should be done in a peaceful period, do not post your stuff every day or every hour. Our group aims to discussions and should not act as a job feed. Your job opportunities must be PHP related. Any other opportunities will be removed. Please use <a href="https://www.fb.com/notes/php/jobs-administrated-document/10151718775065681">dedicated document</a>. We will delete separate topics.'
 
 - title: 'Be social'
   description: 'Our group has no place for harassments, insults or any kind of copyright infringement. You should treat others as you want them to treat you.'
@@ -35,9 +37,6 @@
 
 - title: 'No hijacking topics'
   description: 'Hijacking topics means offtopic advertisements in comments or commenting in a way that should be done by starting a new conversation. Hijacking topics is not allowed.'
-
-- title: 'Job opportunities'
-  description: 'Job opportunities should be done in a peaceful period, do not post your stuff every day or every hour. Our group aims to discussions and should not act as a job feed. Your job opportunities must be PHP related. Any other opportunities will be removed. Work related discrimination is also not allowed here.'
 
 - title: 'No infected urls'
   description: 'Infected urls or topics opened by Facebook Apps or viruses without your knowledge are deleted and your account is not removed right away. If the unwanted postings continue we remove your account as well from the group.'


### PR DESCRIPTION
I've added two new rules, and updated a job ads rule:

1.) Sharing links to Facebook pages should be done only in a dedicated topic for that since we have enormous amount of posts with content "LIKE this page" and similar that only pollute the group's wall and also don't help anyone but the advertiser.

2.) Sharing other Facebook groups should be also done in a dedicated topic

3.) Sharing job opportunities should now be done only through a prepared FB document.